### PR TITLE
fix(client/menus): default window tint

### DIFF
--- a/client/menus/vehicles/options.lua
+++ b/client/menus/vehicles/options.lua
@@ -871,13 +871,16 @@ local function setupModMenu()
     lib.setMenuOptions(id, vehicleModsMenuData['tire_smoke_custom_color_blue'][2], i)
     i += 1
 
-    local defaultWindowTint = GetVehicleWindowTint(cache.vehicle)
-    defaultWindowTint = defaultWindowTint == -1 and 5 or defaultWindowTint
-
+    local currentWindowTint = GetVehicleWindowTint(cache.vehicle)
+    local defaultWindowTint
     local windowTints = {}
 
     for i2 = 1, #vehicleWindowTints do
         windowTints[i2] = vehicleWindowTints[i2][2]
+
+        if currentWindowTint == vehicleWindowTints[i2][1] then
+            defaultWindowTint = i2
+        end
     end
 
     vehicleModsMenuData['window_tint'] = {i, {label = 'Window Tint', description = 'Apply tint to your windows', args = {'window_tint'}, values = windowTints, defaultIndex = defaultWindowTint, close = false}}


### PR DESCRIPTION
I also discovered an issue where green and limo will apply as the same thing, either both green or both limo. No idea where it's coming from and I haven't found a fix unfortunately.