### PR TITLE
Add vehicle teleports to coords and locations

### DIFF
--- a/client/menus/misc/teleport.lua
+++ b/client/menus/misc/teleport.lua
@@ -34,14 +34,14 @@ local function createLocationsMenu()
         end,
         options = menuOptions
     }, function(_, _, args)
-        local currentVeh = GetVehiclePedIsIn(cache.ped, false)
-            if currentVeh ~= 0 then
-                SetEntityCoords(currentVeh, args.coords.x, args.coords.y, args.coords.z, true, false, false, false)
-                SetEntityHeading(currentVeh, args.heading)
-            else
-                SetEntityCoords(cache.ped, args.coords.x, args.coords.y, args.coords.z, true, false, false, false)
-                SetEntityHeading(cache.ped, args.heading)
-            end
+        local currentVeh = cache.vehicle
+        if IsInVehicle(true) then
+            SetEntityCoords(currentVeh, args.coords.x, args.coords.y, args.coords.z, true, false, false, false)
+            SetEntityHeading(currentVeh, args.heading)
+        else
+            SetEntityCoords(cache.ped, args.coords.x, args.coords.y, args.coords.z, true, false, false, false)
+            SetEntityHeading(cache.ped, args.heading)
+        end
 
         lib.notify({
             description = ('Successfully teleport to %s'):format(args.name),
@@ -135,9 +135,8 @@ function SetupTeleportOptions()
                 actualValues[i] = nil
             end
 
-            -- This seems to fix vehicle support for teleporting with coords.
-            local currentVeh = GetVehiclePedIsIn(cache.ped, false)
-            if currentVeh ~= 0 then
+            local currentVeh = cache.vehicle
+            if IsInVehicle(true) then
                 SetEntityCoords(currentVeh, actualValues[1], actualValues[2], actualValues[3], true, false, false, false)
             else
                 SetEntityCoords(cache.ped, actualValues[1], actualValues[2], actualValues[3], true, false, false, false)

--- a/client/menus/misc/teleport.lua
+++ b/client/menus/misc/teleport.lua
@@ -34,9 +34,8 @@ local function createLocationsMenu()
         end,
         options = menuOptions
     }, function(_, _, args)
-        local currentVeh = cache.vehicle
         if IsInVehicle(true) then
-            SetEntityCoords(currentVeh, args.coords.x, args.coords.y, args.coords.z, true, false, false, false)
+            SetEntityCoords(cache.vehicle, args.coords.x, args.coords.y, args.coords.z, true, false, false, false)
             SetEntityHeading(currentVeh, args.heading)
         else
             SetEntityCoords(cache.ped, args.coords.x, args.coords.y, args.coords.z, true, false, false, false)
@@ -135,9 +134,8 @@ function SetupTeleportOptions()
                 actualValues[i] = nil
             end
 
-            local currentVeh = cache.vehicle
             if IsInVehicle(true) then
-                SetEntityCoords(currentVeh, actualValues[1], actualValues[2], actualValues[3], true, false, false, false)
+                SetEntityCoords(cache.vehicle, actualValues[1], actualValues[2], actualValues[3], true, false, false, false)
             else
                 SetEntityCoords(cache.ped, actualValues[1], actualValues[2], actualValues[3], true, false, false, false)
             end

--- a/client/menus/misc/teleport.lua
+++ b/client/menus/misc/teleport.lua
@@ -34,8 +34,15 @@ local function createLocationsMenu()
         end,
         options = menuOptions
     }, function(_, _, args)
-        SetEntityCoords(cache.ped, args.coords.x, args.coords.y, args.coords.z, true, false, false, false)
-        SetEntityHeading(cache.ped, args.heading)
+        local currentVeh = GetVehiclePedIsIn(cache.ped, false)
+            if currentVeh ~= 0 then
+                SetEntityCoords(currentVeh, args.coords.x, args.coords.y, args.coords.z, true, false, false, false)
+                SetEntityHeading(currentVeh, args.heading)
+            else
+                SetEntityCoords(cache.ped, args.coords.x, args.coords.y, args.coords.z, true, false, false, false)
+                SetEntityHeading(cache.ped, args.heading)
+            end
+
         lib.notify({
             description = ('Successfully teleport to %s'):format(args.name),
             type = 'success'
@@ -128,7 +135,13 @@ function SetupTeleportOptions()
                 actualValues[i] = nil
             end
 
-            SetEntityCoords(cache.ped, actualValues[1], actualValues[2], actualValues[3], true, false, false, false)
+            -- This seems to fix vehicle support for teleporting with coords.
+            local currentVeh = GetVehiclePedIsIn(cache.ped, false)
+            if currentVeh ~= 0 then
+                SetEntityCoords(currentVeh, actualValues[1], actualValues[2], actualValues[3], true, false, false, false)
+            else
+                SetEntityCoords(cache.ped, actualValues[1], actualValues[2], actualValues[3], true, false, false, false)
+            end
 
             Wait(200)
             lib.showMenu('bMenu_misc_options_teleport_options', MenuIndexes['bMenu_misc_options_teleport_options'])


### PR DESCRIPTION
I noticed this didn't teleport the players vehicle when teleporting with the coordinate option or the custom teleport locations.
From my testing this did seem to fix this.

Now when the player teleports to a custom coordinate or custom location it'll also teleport their vehicle with them.